### PR TITLE
add renamed .zip file to repo

### DIFF
--- a/bird-photos.zip
+++ b/bird-photos.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b959bac9cb3eaf04588b9991582febd3e88c3ddab8a04234fd3a8491360d9221
-size 393627397
+oid sha256:283fc221d09cf81abb4d8fa2a7af1f034507578167f2f71d07ee08b497227b79
+size 393458411

--- a/bird-photos.zip
+++ b/bird-photos.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b959bac9cb3eaf04588b9991582febd3e88c3ddab8a04234fd3a8491360d9221
+size 393627397


### PR DESCRIPTION
Per Azure DevOps work item 345866, upload identical file that is renamed to use a hyphen instead of an underscore per internal quality standard. @shanamatthews @cassieview 

The edited Learn module references the file name that uses the hyphen. After updates to the content are merged to master, the original file, with the underscore in the file name, can be deleted. 