### PR TITLE
delete original file (renamed)

### DIFF
--- a/bird_photos.zip
+++ b/bird_photos.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b959bac9cb3eaf04588b9991582febd3e88c3ddab8a04234fd3a8491360d9221
-size 393627397


### PR DESCRIPTION
The pull requests deletes the original .zip file because it was renamed in a PR #2. The content and code have been updated to reference the new file name (**bird-photos.zip**).